### PR TITLE
✨feat: 회원가입 및 비밀번호 찾기 시 이메일 인증 구현

### DIFF
--- a/src/main/java/com/project/lettertome_be/domain/auth/controller/EmailAuthController.java
+++ b/src/main/java/com/project/lettertome_be/domain/auth/controller/EmailAuthController.java
@@ -1,0 +1,54 @@
+package com.project.lettertome_be.domain.auth.controller;
+
+import com.project.lettertome_be.domain.auth.service.EmailAuthService;
+import com.project.lettertome_be.domain.user.jwt.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth/email")
+@RequiredArgsConstructor
+public class EmailAuthController {
+
+    private final EmailAuthService emailAuthService;
+    private final JwtUtil jwtUtil;
+
+    // 회원가입 시 이메일 인증 코드를 전송하는 엔드포인트
+    @PostMapping("/send-signup")
+    public ResponseEntity<?> sendSignUpEmailAuthCode(@RequestParam("email") String email) {
+        emailAuthService.sendSignUpEmailAuthCode(email); // 회원가입용 이메일 인증 코드 전송
+        return ResponseEntity.ok().body(Map.of("message", "이메일로 인증 코드를 전송했습니다."));
+    }
+
+    // 회원가입 시 이메일 인증 코드를 검증하는 엔드포인트
+    @PostMapping("/verify-signup")
+    public ResponseEntity<?> verifySignUpEmailAuthCode(@RequestParam("email") String email, @RequestParam("code") String code) {
+        emailAuthService.verifyEmailAuthCode(email, code); // 이메일 인증 코드 검증 (회원가입용)
+        return ResponseEntity.ok().body(Map.of("message", "성공적으로 이메일 인증이 완료되었습니다."));
+    }
+
+    // 비밀번호 재설정 시 이메일 인증 코드를 전송하는 엔드포인트
+    @PostMapping("/send-reset")
+    public ResponseEntity<?> sendPasswordResetEmailAuthCode(@RequestParam("email") String email) {
+        emailAuthService.sendPasswordResetEmailAuthCode(email); // 비밀번호 재설정용 이메일 인증 코드 전송
+        return ResponseEntity.ok().body(Map.of("message", "이메일로 인증 코드를 전송했습니다."));
+    }
+
+    // 비밀번호 재설정 시 이메일 인증 코드를 검증하고 임시 AccessToken을 발급하는 엔드포인트
+    @PostMapping("/verify-reset")
+    public ResponseEntity<?> verifyResetEmailAuthCode(@RequestParam("email") String email, @RequestParam("code") String code) {
+        emailAuthService.verifyEmailAuthCode(email, code); // 이메일 인증 코드 검증 (비밀번호 재설정용)
+
+        //임시 AccessToken 생성
+        String temporaryToken = jwtUtil.createTemporaryToken(email, 5 * 60 * 1000); // 5분 유효
+
+        return ResponseEntity.ok().body(Map.of("message", "성공적으로 이메일 인증이 완료되었습니다.","temporaryToken", temporaryToken));
+    }
+
+}

--- a/src/main/java/com/project/lettertome_be/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/com/project/lettertome_be/domain/auth/service/EmailAuthService.java
@@ -1,0 +1,71 @@
+package com.project.lettertome_be.domain.auth.service;
+
+import com.project.lettertome_be.domain.user.repository.UserRepository;
+import com.project.lettertome_be.global.common.sender.DefaultEmailSender;
+import com.project.lettertome_be.global.common.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailAuthService {
+    private final RedisUtil redisUtil;
+    private final DefaultEmailSender emailSender;
+    private final UserRepository userRepository;
+
+    @Value("${spring.mail.auth-code-expiration-millis}")
+    private long authCodeExpirationMillis; //인증 코드의 유효시간
+
+    // 회원가입 시 이메일 인증 코드를 생성하고 전송하는 메서드
+    public void sendSignUpEmailAuthCode(String email) {
+        // 이메일이 이미 DB에 존재하는지 확인
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        String authCode = createCode(); // 인증 코드 생성
+        emailSender.sendAuthCodeForSignUp(email, authCode); // 이메일로 인증 코드 전송
+        redisUtil.save(email, authCode, authCodeExpirationMillis, TimeUnit.MILLISECONDS); // Redis에 인증 코드 저장
+    }
+
+    // 이메일 인증 코드를 검증하는 메서드
+    public void verifyEmailAuthCode(String email, String authCode) {
+        String storedAuthCode = (String) redisUtil.get(email);
+
+        if (!authCode.equals(storedAuthCode)) {
+            throw new IllegalArgumentException("인증 코드가 일치하지 않습니다.");
+        }
+        redisUtil.delete(email); // 인증 성공 시 Redis에서 인증 코드 삭제
+    }
+
+    // 비밀번호 재설정 시 이메일 인증 코드를 생성하고 전송하는 메서드
+    public void sendPasswordResetEmailAuthCode(String email) {
+        // 이메일이 DB에 존재하는지 확인
+        if (!userRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("해당 이메일로 등록된 사용자가 없습니다.");
+        }
+
+        String authCode = createCode(); // 인증 코드 생성
+        emailSender.sendAuthCodeForPasswordReset(email, authCode); // 비밀번호 재설정을 위한 인증 코드 전송
+        redisUtil.save(email, authCode, authCodeExpirationMillis, TimeUnit.MILLISECONDS); // Redis에 인증 코드 저장
+    }
+
+    // 인증 코드 생성 메서드
+    private String createCode() {
+        int length = 8; // 인증 코드 길이
+        StringBuilder builder = new StringBuilder();
+        String characters = "abcdefghijklmnopqrstuvwxyz0123456789"; // 소문자와 숫자 포함
+
+        for (int i = 0; i < length; i++) {
+            int randomIndex = (int) (Math.random() * characters.length()); // 무작위 인덱스 생성
+            builder.append(characters.charAt(randomIndex)); // 해당 인덱스의 문자를 추가
+        }
+
+        return builder.toString(); // 생성된 인증 코드 반환
+    }
+}

--- a/src/main/java/com/project/lettertome_be/domain/user/jwt/util/JwtUtil.java
+++ b/src/main/java/com/project/lettertome_be/domain/user/jwt/util/JwtUtil.java
@@ -109,6 +109,26 @@ public class JwtUtil {
         return refreshToken;
     }
 
+    // 임시 AccessToken을 생성하는 메서드
+    public String createTemporaryToken(String email, long expirationTimeInMillis) {
+        log.info("[ JwtUtil ] 임시 AccessToken을 생성합니다.");
+
+        Instant issuedAt = Instant.now();
+        Instant expirationTime = Instant.now().plusMillis(expirationTimeInMillis);
+
+        // 임시 AccessToken 생성
+        return Jwts.builder()
+                .header()
+                .add("typ", "JWT")
+                .and()
+                .subject(email) // Subject에 사용자 이메일 추가
+                .claim("scope", "password-reset") // 특정 작업(scope)을 위한 클레임 추가
+                .issuedAt(Date.from(issuedAt)) // 발행 시간
+                .expiration(Date.from(expirationTime)) // 만료 시간
+                .signWith(secretKey) // 서명 정보 추가
+                .compact(); // 토큰 생성
+    }
+
     // 제공된 리프레시 토큰을 기반으로 JwtDto 쌍을 다시 발급
     public JwtDto reissueToken(String refreshToken) throws SignatureException {
         String email = getEmail(refreshToken);

--- a/src/main/java/com/project/lettertome_be/global/common/sender/DefaultEmailSender.java
+++ b/src/main/java/com/project/lettertome_be/global/common/sender/DefaultEmailSender.java
@@ -1,0 +1,67 @@
+package com.project.lettertome_be.global.common.sender;
+
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+
+@Slf4j
+@Component
+public class DefaultEmailSender {
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final String serviceEmail;
+
+    public DefaultEmailSender(
+            final JavaMailSender mailSender,
+            final SpringTemplateEngine templateEngine,
+            @Value("${spring.mail.username}") final String serviceEmail
+    ) {
+        this.mailSender = mailSender;
+        this.templateEngine = templateEngine;
+        this.serviceEmail = serviceEmail;
+    }
+
+    public void sendAuthCodeForSignUp(final String targetEmail, final String authCode) {
+        // 회원가입 시 이메일로 인증 코드를 전송하는 메서드
+        final Context context = new Context(); // 이메일 템플릿에 사용할 컨텍스트를 생성
+        context.setVariable("authCode", authCode); // 컨텍스트에 인증 코드를 설정
+
+        final String mailBody = templateEngine.process("EmailAuthCodeTemplate", context); // 이메일 본문을 생성
+        sendMail("회원가입 인증번호 메일입니다.", targetEmail, mailBody); // 이메일을 전송
+    }
+
+    public void sendAuthCodeForPasswordReset(final String targetEmail, final String authCode) {
+        // 회원가입 시 이메일로 인증 코드를 전송하는 메서드
+        final Context context = new Context(); // 이메일 템플릿에 사용할 컨텍스트를 생성
+        context.setVariable("authCode", authCode); // 컨텍스트에 인증 코드를 설정
+
+        final String mailBody = templateEngine.process("EmailAuthCodeTemplate", context); // 이메일 본문을 생성
+        sendMail("비밀번호 변경 인증번호 메일입니다.", targetEmail, mailBody); // 이메일을 전송
+    }
+
+    private void sendMail(final String subject, final String email, final String mailBody) {
+        // 이메일을 전송하는 메서드
+        try {
+            final MimeMessage message = mailSender.createMimeMessage(); // MIME 메시지를 생성
+            final MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8"); // MIME 메시지 헬퍼를 생성
+
+            helper.setSubject(subject); // 이메일 제목을 설정
+            helper.setTo(email); // 수신자를 설정
+            helper.setFrom(new InternetAddress(serviceEmail, "Another Art")); // 발신자를 설정
+            helper.setText(mailBody, true); // 이메일 본문을 설정
+
+            mailSender.send(message); // 이메일을 전송
+        } catch (final Exception e) {
+            log.warn("메일 전송 간 오류 발생...", e);
+            throw new IllegalArgumentException("메일을 전송할 수 없습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/project/lettertome_be/global/config/EmailConfig.java
+++ b/src/main/java/com/project/lettertome_be/global/config/EmailConfig.java
@@ -1,0 +1,62 @@
+package com.project.lettertome_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.smtp.write-timeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.starttls.required", starttlsRequired);
+        props.put("mail.smtp.connection-timeout", connectionTimeout);
+        props.put("mail.smtp.timeout", timeout);
+        props.put("mail.smtp.write-timeout", writeTimeout);
+
+        return mailSender;
+    }
+}

--- a/src/main/resources/templates/EmailAuthCodeTemplate.html
+++ b/src/main/resources/templates/EmailAuthCodeTemplate.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>Another Art</title>
+</head>
+<body>
+<p style="font-size:10pt; font-family:sans-serif; padding:0 0 0 10pt"><br><br></p>
+<div style="width:440px; margin:30px auto; padding:40px 0 60px; background-color:#fff; border:1px solid #ddd; text-align:center; font-size:16px; font-family:malgun gothic,serif;">
+    <h3 style="font-weight:bold; font-size:20px; margin:28px auto;">Letter To Me 💌 이메일 본인인증</h3>
+    <div style="width:200px; margin:28px auto; padding:8px 0 9px; background-color:#f4f4f4; border-radius:3px;">
+        <span style="display:inline-block; vertical-align:middle; font-size:13px; color:#666;">인증번호</span>
+        <span style="display:inline-block; margin-left:16px; vertical-align:middle; font-size:21px; font-weight:bold; color:#4d5642;" th:text="${authCode}"></span>
+    </div>
+    <p style="text-align:center; font-size:13px; color:#000; line-height:1.6; margin-top:40px; margin-bottom:0;">
+        해당 인증번호를 인증 번호 확인란에 기입하여 주세요.<br>
+        Letter To Me 💌 를 이용해 주셔서 감사합니다.<br>
+    </p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# ☝️Issue Number

- #25 

# 🔎 Key Changes
- 회원가입 및 비밀번호 찾기 시 이메일 인증 구현
- 테스트 완료

# 💌 To Reviewers
- 비밀번호 찾기 시, 이메일 인증 후 비밀번호 변경만 가능한 임시 토큰을 발급하여 비밀번호 변경이 가능하도록 구현함.(토큰은 5분 유효)